### PR TITLE
API no longer returns passwords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Run this from the command line to print the usage:
      ps:usage <name>                    # list historical memory & CPU usage for <name>
 
      users                              # list user accounts: details
-     users:pw                           # list user accounts: usernames & passwords
 
+Listing of passwords is no longer supported by the Dreamhost API.
      
 That's it for now. New commands should be springing up as Dreamy and the DreamHost API mature!
 

--- a/lib/dreamy/commands/help.rb
+++ b/lib/dreamy/commands/help.rb
@@ -40,7 +40,6 @@ module Dreamy::Command
  ps:usage <name>                    # list historical memory & CPU usage for <name>
  
  users                              # list user accounts: details
- users:pw                           # list user accounts: usernames & passwords
 
 EOTXT
 		end

--- a/lib/dreamy/commands/users.rb
+++ b/lib/dreamy/commands/users.rb
@@ -1,6 +1,10 @@
 module Dreamy::Command
   class Users < Base
     
+    # Command: 
+    #    dh users
+    #
+    # Print table of users
     def index
       users = @account.users
       if users.empty?
@@ -13,20 +17,6 @@ module Dreamy::Command
         display user_table
       end
     end
-    
-    def pw
-      users = @account.users(passwords=true)
-      if users.empty?
-        display "No users on this account"
-      else
-        user_table = table do |t|
-          t.headings = 'UserName', 'Password'
-          users.each { |u| t << [u.username, u.password]  }
-        end
-        display user_table
         
-      end
-    end
-    
   end
 end

--- a/lib/dreamy/user.rb
+++ b/lib/dreamy/user.rb
@@ -10,7 +10,6 @@ module Dreamy
       u.disk_used_mb  = (xml).at('disk_used_mb').innerHTML.to_f
       u.gecos         = (xml).at('gecos').innerHTML
       u.home          = (xml).at('home').innerHTML
-      u.password      = (xml).at('password').innerHTML
       u.quota_mb      = (xml).at('quota_mb').innerHTML.to_i
       u.shell         = (xml).at('shell').innerHTML
       u.type          = (xml).at('type').innerHTML

--- a/test/user_test.rb
+++ b/test/user_test.rb
@@ -10,7 +10,6 @@ class DreamyUserTest < Test::Unit::TestCase
     <disk_used_mb>123.04</disk_used_mb>
     <gecos>Joe Schmoe</gecos>
     <home>spork.Dreamy.com</home>
-    <password>YahRight!</password>
     <quota_mb>50</quota_mb>
     <shell>/bin/bash</shell>
     <type>mail</type>
@@ -25,7 +24,6 @@ EOF
       assert_equal 123.04, u.disk_used_mb
       assert_equal "Joe Schmoe", u.gecos
       assert_equal "spork.Dreamy.com", u.home
-      assert_equal "YahRight!", u.password
       assert_equal 50, u.quota_mb
       assert_equal "/bin/bash", u.shell
       assert_equal "mail", u.type


### PR DESCRIPTION
The dreamhost API no longer returns passwords when querying for users. This caused an error in the 'users' and 'users:pw' commands.

this branch
- don't look for a password field in the XML that isn't there
- users:pw has been deleted since it no longer makes sense
- update unit test
- update help
- update README
