### PR TITLE
Add support for api-list_accessible_cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Run this from the command line to print the usage:
 
      users                              # list user accounts: details
 
+     api:cmds                           # list all API commands the current API key has access to
+     api:cmd_args                       # list all API commands including argument and result fields
+
 Listing of passwords is no longer supported by the Dreamhost API.
      
 That's it for now. New commands should be springing up as Dreamy and the DreamHost API mature!

--- a/lib/dreamy/base.rb
+++ b/lib/dreamy/base.rb
@@ -213,6 +213,17 @@ module Dreamy
       (doc/:data).inject([]) { |pends, pend| pends << PrivateServer.pending_from_xml(pend); pends }
     end
 
+    def api_cmds
+      doc = request("api-list_accessible_cmds")
+      api_error?(doc)
+      (doc/:data).inject([]) do |cmds, cmd|  
+        cmds << [ (cmd/:cmd).first.inner_html,
+                  (cmd/:args).map {|_| _.inner_html},
+                  (cmd/:order).map {|_| _.inner_html} ]
+        cmds
+      end
+    end
+
     private
     
     def api_error?(doc)

--- a/lib/dreamy/commands/api.rb
+++ b/lib/dreamy/commands/api.rb
@@ -1,0 +1,36 @@
+module Dreamy::Command
+  class Api < Base
+    def cmds
+      cmds = @account.api_cmds
+      cmd_table = table do |t|
+        t.headings = ['Command']
+        cmds.each do |c| 
+          t << [c.first]
+        end
+      end
+      display cmd_table
+    end
+
+    def cmd_args
+      cmds = @account.api_cmds
+      cmd_table = table do |t|
+        t.headings = 'Command', 'Arguments', 'Results'
+        cmds.each do |c| 
+          cmd, args, results = *c
+          if args.empty? && results.empty?
+            t << c
+          else
+            [args.size, results.size].max.times do
+              arg = args.shift
+              result = results.shift
+              t << [cmd, arg, result]
+              cmd = ''
+            end
+          end
+        end
+      end
+      display cmd_table
+    end
+
+  end
+end

--- a/lib/dreamy/commands/help.rb
+++ b/lib/dreamy/commands/help.rb
@@ -41,6 +41,9 @@ module Dreamy::Command
  
  users                              # list user accounts: details
 
+ api:cmds                           # list all API commands the current API key has access to
+ api:cmd_args                       # list all API commands including argument and result fields                                    
+
 EOTXT
 		end
 	end


### PR DESCRIPTION
This patch adds two new commands, they both use api-list_accessible_cmds to list commands that the current API can access

```
dh api:cmds

+----------------------------------+
| Command                          |
+----------------------------------+
| account-domain_usage             |
| account-list_accounts            |
| account-list_keys                |
| account-status                   |
| account-user_usage               |
| api-list_accessible_cmds         |
| api-list_keys                    |
| domain-list_certificates         |
| domain-list_domains              |
| domain-list_registrations        |
| domain-registration_available    |
| dreamhost_ps-add_key             |
| dreamhost_ps-add_ps              |
+----------------------------------+


dh api:cmd_args

+----------------------------------+----------------+--------------------+
| Command                          | Arguments      | Results            |
+----------------------------------+----------------+--------------------+
| account-domain_usage             |                | domain             |
|                                  |                | type               |
|                                  |                | bw                 |
| account-list_accounts            |                | account_id         |
|                                  |                | name               |
|                                  |                | status             |
|                                  |                | opened             |
|                                  |                | yours              |
| domain-registration_available    | domain         | available          |
| dreamhost_ps-add_key             | key_name       | added_key          |
|                                  | ps_name        |                    |
| dreamhost_ps-add_ps              | type           | ps_name            |
|                                  |                | token              |
+----------------------------------+----------------+--------------------+
```
